### PR TITLE
Add Integration tests and address n+1 problem

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,19 @@
 class PostsController < ApplicationController
-  def index  
-   @posts = Post.includes(:author, comments:[:author]).where(author_id: params[:user_id]).order(created_at: :desc).limit(2)
-   @first_post = @posts[0]
+  def index
+    Rails.logger.info(params[:user_id])
+    @posts = Post.includes(:author,
+                           comments: [:author]).where(author_id: params[:user_id]).order(created_at: :desc).limit(2)
+    @first_post = @posts[0]
+    @posts.each do |post|
+      Rails.logger.info(post.title || 'No title')
+      Rails.logger.info(post.text || 'No text')
+    end
+
+    Rails.logger.info(@first_post.author.name || 'No name')
   end
 
   def show
-    @post = Post.includes(:author, comments:[:author]).where(author_id: params[:user_id]).find(params[:id])
+    @post = Post.includes(:author, comments: [:author]).where(author_id: params[:user_id]).find(params[:id])
     comment = Comment.new
     like = Like.new
     respond_to do |format|

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,13 @@
 class PostsController < ApplicationController
-  def index
-    @user = User.find(params[:user_id])
-    @posts = Post.where(author_id: params[:user_id]).order(created_at: :desc).limit(2)
+  def index  
+   @posts = Post.includes(:author, comments:[:author]).where(author_id: params[:user_id]).order(created_at: :desc).limit(2)
+   @first_post = @posts[0]
   end
 
   def show
-    @user = User.find(params[:user_id])
-    @post = Post.where(author_id: params[:user_id]).find(params[:id])
+    #@user = User.find(params[:user_id])
+    #@post = Post.where(author_id: params[:user_id]).find(params[:id])
+    @post = Post.includes(:author, comments:[:author]).where(author_id: params[:user_id]).find(params[:id])
     comment = Comment.new
     like = Like.new
     respond_to do |format|

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,8 +5,6 @@ class PostsController < ApplicationController
   end
 
   def show
-    #@user = User.find(params[:user_id])
-    #@post = Post.where(author_id: params[:user_id]).find(params[:id])
     @post = Post.includes(:author, comments:[:author]).where(author_id: params[:user_id]).find(params[:id])
     comment = Comment.new
     like = Like.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,6 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.includes(:posts).find(params[:id])
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,14 +1,14 @@
 <div class="container">
     <h1>Posts List</h1>
-    <%= render partial: "/shared/user", locals: { user: @user } %>
+    <%= render partial: "/shared/user", locals: { user: @first_post.author } %>
     <div class="user-posts">
         <% @posts.each.with_index(1) do |post, index| %>
             <div class="post-with-comments">
-            <a href="/users<%= @user.id %>/posts<%= post.id %>">
+            <a href="/users<%= post.author.id %>/posts<%= post.id %>">
                 <%= render partial: "/shared/post", locals: { post: post, index: index } %>
             </a>
                 <div class="comments">
-                    <% post.five_most_recent_comments_for_post.each do |comment| %>
+                    <% post.comments[0...5].each do |comment| %>
                         <%= render partial: "/shared/comment", locals: { comment: comment } %>
                     <% end %>
                 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,7 +2,7 @@
     <h1>Posts Detail</h1>
     <div class="post-detail">
         <div class="post-head">
-            <h5>Post <%=@post.id %> <%= @post.title %> <% 'by' %> <%= @user.name %></h5>
+            <h5>Post <%=@post.id %> <%= @post.title %> <% 'by' %> <%= @post.author.name %></h5>
             <ul>
             <li class="like-form">
                     <%= form_with model: like, method: :post, url: new_user_like_path, local: true, scope: :new_like do |form| %>
@@ -36,7 +36,7 @@
             <%= form.submit "Submit", class: "btn btn-primary" %>
         <% end %>
         <h5>Recent Comments</h5>
-        <% @post.comments.order(created_at: :desc).each do |comment| %>
+        <% @post.comments.each do |comment| %>
             <%= render partial: "/shared/comment", locals: { comment: comment } %>
         <% end %>
     </div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -63,7 +63,7 @@ test:
   database: blog_app
   host: localhost
   password: postgres
-  port: 5433
+  port: 5432
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/comment_spec.rb
+++ b/spec/comment_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Comment, type: :model do
   subject { Comment.new(author_id: 1, post_id: 1) }
 
   it 'increments comments_counter of post' do
-    user = User.create(Name: 'John Doe', PostsCounter: 0)
+    user = User.create(name: 'John Doe', posts_counter: 0)
 
-    post = user.posts.build(Title: 'Post 1', CommentsCounter: 0, LikesCounter: 0)
+    post = user.posts.build(title: 'Post 1', comments_counter: 0, likes_counter: 0)
     post.author_id = user.id
     post.save!
     comment = post.comments.build(author_id: user.id)
     comment.post_id = post.id
     comment.save!
-    expect(Post.find(post.id).CommentsCounter).to eq(1)
+    expect(Post.find(post.id).comments_counter).to eq(1)
   end
 end

--- a/spec/like_spec.rb
+++ b/spec/like_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Like, type: :model do
   subject { Like.new(author_id: 1, post_id: 1) }
 
   it 'increments likes_counter of post' do
-    user = User.create(Name: 'John Doe', PostsCounter: 0)
-    post = user.posts.build(Title: 'Post 1', CommentsCounter: 0, LikesCounter: 0)
+    user = User.create(name: 'John Doe', posts_counter: 0)
+    post = user.posts.build(title: 'Post 1', comments_counter: 0, likes_counter: 0)
     post.author_id = user.id
     post.save!
     like = post.likes.build(author_id: user.id)
     like.post_id = post.id
     like.save!
-    expect(Post.find(post.id).LikesCounter).to eq(1)
+    expect(Post.find(post.id).likes_counter).to eq(1)
   end
 end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -1,37 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  subject { Post.new(Title: 'My first post', author_id: 1, CommentsCounter: 0, LikesCounter: 0) }
+  subject { Post.new(title: 'My first post', author_id: 1, comments_counter: 0, likes_counter: 0) }
 
   before { subject.save }
 
   it 'Title should be present' do
-    subject.Title = ''
+    subject.title = ''
     expect(subject).to_not be_valid
   end
 
   it 'Title should not be too long' do
-    subject.Title = 'a' * 251
+    subject.title = 'a' * 251
     expect(subject).to_not be_valid
   end
 
   it 'CommentsCounter should be integer' do
-    subject.CommentsCounter = '10'
+    subject.comments_counter = '10'
     expect(subject).to_not be_valid
   end
 
   it 'CommentsCounter should be greater than or equal to 0' do
-    subject.CommentsCounter = -1
+    subject.comments_counter = -1
     expect(subject).to_not be_valid
   end
 
   it 'LikesCounter should be integer' do
-    subject.LikesCounter = '10'
+    subject.likes_counter = '10'
     expect(subject).to_not be_valid
   end
 
   it 'LikesCounter should be greater than or equal to 0' do
-    subject.LikesCounter = -1
+    subject.likes_counter = -1
     expect(subject).to_not be_valid
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'capybara/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -1,36 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
- let(:user) { User.create(id: 99, name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.') }
- let(:post) { Post.create(title: 'Post 3', text: 'This is my third post', author: user) }
+  before(:each) do
+    @user = User.create(
+      name: 'Tom',
+      bio: 'Teacher from Mexico.',
+      photo: 'https://unsplash.com/photos/F_-0BxGuVvo',
+      posts_counter: 2
+    )
+
+    @post = Post.create(
+      author: @user,
+      title: 'Post 3',
+      text: 'This is my third post',
+      comments_counter: 0,
+      likes_counter: 0
+    )
+  end
 
   it 'should get index' do
-    get "/users#{user.id}/posts"
+    get user_posts_path(@user)
     expect(response).to have_http_status(200)
   end
 
   it 'should get show' do
-    get "/users#{user.id}/posts#{post.id}"
+    get user_post_path(@user, @post)
     expect(response).to have_http_status(200)
   end
 
   it 'returns correct show template' do
-    get "/users#{user.id}/posts#{post.id}"
+    get user_post_path(@user, @post)
     expect(response).to render_template(:show)
   end
 
   it 'returns correct index template' do
-    get "/users#{user.id}/posts"
+    get user_posts_path(@user)
     expect(response).to render_template(:index)
   end
 
   it 'gets correct response body' do
-    get "/users#{user.id}/posts#{post.id}"
-    expect(response.body).to include('Here is a post for a given user')
+    get user_post_path(@user, @post)
+    expect(response.body).to include('Posts Detail')
   end
 
   it 'gets correct response body' do
-    get "/users#{user.id}/posts"
-    expect(response.body).to include('Here is a list of posts for a given user')
+    get user_posts_path(@user)
+    expect(response.body).to include('Posts List')
   end
 end

--- a/spec/requests/posts_request_spec.rb
+++ b/spec/requests/posts_request_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
-  let(:user) { User.create(id: 1, Name: 'Tom', Photo: 'https://unsplash.com/photos/F_-0BxGuVvo', Bio: 'Teacher from Mexico.') }
-  let(:post) { Post.create(id: 1, author_id: user.id, Title: 'Post 3', Text: 'This is my third post') }
+ let(:user) { User.create(id: 99, name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.') }
+ let(:post) { Post.create(title: 'Post 3', text: 'This is my third post', author: user) }
 
   it 'should get index' do
     get "/users#{user.id}/posts"

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,7 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
-  let(:user) { User.create(id: 2, name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.') }
+  before(:each) do
+    @user = User.create(
+      name: 'Tom',
+      bio: 'Teacher from Mexico.',
+      photo: 'https://unsplash.com/photos/F_-0BxGuVvo',
+      posts_counter: 2
+    )
+  end
 
   it 'should get index' do
     get '/users'
@@ -9,12 +16,12 @@ RSpec.describe 'Users', type: :request do
   end
 
   it 'should get show' do
-    get "/users#{user.id}"
+    get user_path(@user)
     expect(response).to have_http_status(200)
   end
 
   it 'return correct show template' do
-    get "/users#{user.id}"
+    get user_path(@user)
     expect(response).to render_template(:show)
   end
 
@@ -24,7 +31,7 @@ RSpec.describe 'Users', type: :request do
   end
 
   it 'gets correct response body' do
-    get "/users#{user.id}"
+    get user_path(@user)
     expect(response.body).to include('User Detail')
   end
 

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
-  let(:user) { User.create(id: 2, Name: 'Tom', Photo: 'https://unsplash.com/photos/F_-0BxGuVvo', Bio: 'Teacher from Mexico.') }
+  let(:user) { User.create(id: 2, name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.') }
 
   it 'should get index' do
     get '/users'

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  subject { User.new(Name: 'Tom', Photo: 'https://unsplash.com/photos/F_-0BxGuVvo', Bio: 'Teacher from Mexico.') }
+  subject { User.new(name: 'Tom', photo: 'https://unsplash.com/photos/F_-0BxGuVvo', bio: 'Teacher from Mexico.') }
 
   before { subject.save }
 
   it 'Name should be present' do
-    subject.Name = nil
+    subject.name = nil
     expect(subject).to_not be_valid
   end
 
   it 'PostsCounter should be greater than or equal to 0' do
-    subject.PostsCounter = -1
+    subject.posts_counter = -1
     expect(subject).to_not be_valid
   end
 
   it 'PostsCounter should be greater than or equal to 0' do
-    subject.PostsCounter = 15
+    subject.posts_counter = 15
     expect(subject).to be_valid
   end
 

--- a/spec/views/post_index_spec.rb
+++ b/spec/views/post_index_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe 'Post index page', type: :feature do
+  before(:each) do
+    @user = User.create(
+        name: 'Abdul',
+        bio: 'Aspiring FullStack Dev',
+        photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
+        posts_counter: 2
+        )
+
+    @user2 = User.create(
+        name: 'Jonathan',
+        bio: 'FullStack Dev',
+        photo: 'https://unsplash.com/photos/hodKTZow_Kk',
+        posts_counter: 2
+    )
+
+    @post1 = Post.create(
+        title: 'Test',
+        text: 'First Post',
+        author: @user
+    )
+
+    @post2 = Post.create(
+        title: 'Working?',
+        text: 'Second Post',
+        author: @user
+    )
+
+    @comment1 = Comment.create(
+        text: 'First Comment',
+        post: @post1,
+        author_id: @user2
+    )
+
+    @comment2 = Comment.create(
+        text: 'Second Comment',
+        post: @post2,
+        author_id: @user2
+    )
+
+    @like1 = Like.create(
+        post: @post1,
+        author_id: @user2
+    )
+
+    end
+
+    describe 'the post index page' do
+        it 'displays the users profile picture' do
+            visit user_posts_path(@user)
+            expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
+        end
+
+        it 'displays the users username' do
+            visit user_posts_path(@user)
+            expect(page).to have_content('Abdul')
+        end
+
+        it 'displays the number of posts the user has written' do
+            visit user_posts_path(@user)
+            expect(page).to have_content('2')
+        end
+
+        it 'displays the post title' do
+            visit user_posts_path(@user)
+            expect(page).to have_content('Test')
+            expect(page).to have_content('Working?')
+        end
+    
+        it 'displays the post text' do
+            visit user_posts_path(@user)
+            expect(page).to have_content('First Post')
+            expect(page).to have_content('Second Post')
+            expect(page).to_not have_content('This post')
+        end
+    
+        it 'displays the first comment' do
+            visit user_posts_path(@user)
+            expect(page).to have_content('First Comment')
+        end
+            
+    
+        it 'displays the number of comments' do
+            visit user_posts_path(@user)
+            expect(page).to have_content('2')
+        end
+    
+        it 'displays the number of likes' do
+            visit user_posts_path(@user)
+            expect(page).to have_content('1')
+        end
+
+        it 'displays Show all posts button' do
+            visit user_posts_path(@user)
+            expect(page).to have_content('Show all posts')
+        end
+
+        it 'redirects to the post show page when clicked' do
+            visit user_posts_path(@user)
+            click_link 'First Post'
+            expect(page).to have_current_path(post_path(@post1))
+        end
+    end
+end

--- a/spec/views/post_index_spec.rb
+++ b/spec/views/post_index_spec.rb
@@ -2,105 +2,70 @@ require 'rails_helper'
 
 RSpec.describe 'Post index page', type: :feature do
   before(:each) do
-    @user = User.create(
-        name: 'Abdul',
-        bio: 'Aspiring FullStack Dev',
-        photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
-        posts_counter: 2
-        )
+    @user = User.create(name: 'Abdul', bio: 'Aspiring FullStack Dev', photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
+                        posts_counter: 2)
+    @user2 = User.create(name: 'Jonathan', bio: 'FullStack Dev', photo: 'https://unsplash.com/photos/hodKTZow_Kk',
+                         posts_counter: 2)
+    @post1 = Post.create(title: 'Test', text: 'First Post', comments_counter: 0, likes_counter: 0, author: @user)
+    @post2 = Post.create(title: 'Working?', text: 'Second Post', comments_counter: 0, likes_counter: 0, author: @user)
+    @comment1 = Comment.create(text: 'First Comment', post: @post1, author: @user2)
+    @comment2 = Comment.create(text: 'Second Comment', post: @post2, author: @user2)
+    @like1 = Like.create(post: @post1, author: @user2)
+  end
 
-    @user2 = User.create(
-        name: 'Jonathan',
-        bio: 'FullStack Dev',
-        photo: 'https://unsplash.com/photos/hodKTZow_Kk',
-        posts_counter: 2
-    )
-
-    @post1 = Post.create(
-        title: 'Test',
-        text: 'First Post',
-        author: @user
-    )
-
-    @post2 = Post.create(
-        title: 'Working?',
-        text: 'Second Post',
-        author: @user
-    )
-
-    @comment1 = Comment.create(
-        text: 'First Comment',
-        post: @post1,
-        author_id: @user2
-    )
-
-    @comment2 = Comment.create(
-        text: 'Second Comment',
-        post: @post2,
-        author_id: @user2
-    )
-
-    @like1 = Like.create(
-        post: @post1,
-        author_id: @user2
-    )
-
+  describe 'the post index page' do
+    it 'displays the users profile picture' do
+      visit user_posts_path(@user)
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
     end
 
-    describe 'the post index page' do
-        it 'displays the users profile picture' do
-            visit user_posts_path(@user)
-            expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
-        end
-
-        it 'displays the users username' do
-            visit user_posts_path(@user)
-            expect(page).to have_content('Abdul')
-        end
-
-        it 'displays the number of posts the user has written' do
-            visit user_posts_path(@user)
-            expect(page).to have_content('2')
-        end
-
-        it 'displays the post title' do
-            visit user_posts_path(@user)
-            expect(page).to have_content('Test')
-            expect(page).to have_content('Working?')
-        end
-    
-        it 'displays the post text' do
-            visit user_posts_path(@user)
-            expect(page).to have_content('First Post')
-            expect(page).to have_content('Second Post')
-            expect(page).to_not have_content('This post')
-        end
-    
-        it 'displays the first comment' do
-            visit user_posts_path(@user)
-            expect(page).to have_content('First Comment')
-        end
-            
-    
-        it 'displays the number of comments' do
-            visit user_posts_path(@user)
-            expect(page).to have_content('2')
-        end
-    
-        it 'displays the number of likes' do
-            visit user_posts_path(@user)
-            expect(page).to have_content('1')
-        end
-
-        it 'displays Show all posts button' do
-            visit user_posts_path(@user)
-            expect(page).to have_content('Show all posts')
-        end
-
-        it 'redirects to the post show page when clicked' do
-            visit user_posts_path(@user)
-            click_link 'First Post'
-            expect(page).to have_current_path(post_path(@post1))
-        end
+    it 'displays the users username' do
+      visit user_posts_path(@user)
+      expect(page).to have_content('Abdul')
     end
+
+    it 'displays the number of posts the user has written' do
+      visit user_posts_path(@user)
+      expect(page).to have_content('2')
+    end
+
+    it 'displays the post title' do
+      visit user_posts_path(@user)
+      expect(page).to have_content('Test')
+      expect(page).to have_content('Working?')
+    end
+
+    it 'displays the post text' do
+      visit user_posts_path(@user)
+      expect(page).to have_content('First Post')
+      expect(page).to have_content('Second Post')
+      expect(page).to_not have_content('This post')
+    end
+
+    it 'displays the first comment' do
+      visit user_posts_path(@user)
+      expect(page).to have_content('First Comment')
+    end
+
+    it 'displays the number of comments' do
+      visit user_posts_path(@user)
+      expect(page).to have_content('2')
+    end
+
+    it 'displays the number of likes' do
+      visit user_posts_path(@user)
+      expect(page).to have_content('1')
+    end
+
+    it 'displays Show all posts button' do
+      visit user_posts_path(@user)
+      expect(page).to have_content('More Posts')
+    end
+
+    it 'redirects to the post show page when clicked' do
+      visit user_posts_path(@user)
+      click_link 'First Post'
+      expect(page).to have_current_path(user_post_path(@user, @post1))
+    end
+  end
 end

--- a/spec/views/post_show_spec.rb
+++ b/spec/views/post_show_spec.rb
@@ -1,73 +1,75 @@
 require 'rails_helper'
 
 RSpec.describe 'Post show page', type: :feature do
-    before(:each) do
-        @user = User.create(
-            name: 'Abdul',
-            bio: 'Aspiring FullStack Dev',
-            photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
-        )
+  before(:each) do
+    @user = User.create(
+      name: 'Abdul',
+      bio: 'Aspiring FullStack Dev',
+      photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
+      posts_counter: 2
+    )
 
-        @user2 = User.create(
-            name: 'Jonathan',
-            bio: 'FullStack Dev',
-            photo: 'https://unsplash.com/photos/hodKTZow_Kk',
-        )
+    @user2 = User.create(
+      name: 'Jonathan',
+      bio: 'FullStack Dev',
+      photo: 'https://unsplash.com/photos/hodKTZow_Kk',
+      posts_counter: 2
+    )
 
-        @post1 = Post.create(
-            title: 'Test',
-            text: 'First Post',
-            author: @user
-        )
+    @post1 = Post.create(
+      title: 'Test',
+      text: 'First Post',
+      comments_counter: 0,
+      likes_counter: 0,
+      author: @user
+    )
 
-        @comment1 = Comment.create(
-            text: 'First Comment',
-            post: @post1,
-            author: @user2
-        )
+    @comment1 = Comment.create(
+      text: 'First Comment',
+      post: @post1,
+      author: @user2
+    )
 
-        @like1 = Like.create(
-            post: @post1,
-            author: @user2
-        )
+    @like1 = Like.create(
+      post: @post1,
+      author: @user2
+    )
+  end
 
+  describe 'the post show page' do
+    it 'displays the post title' do
+      visit user_post_path(@user, @post1)
+      expect(page).to have_content('Test')
     end
 
-    describe 'the post show page' do
-        it 'displays the post title' do
-            visit post_path(@post1)
-            expect(page).to have_content('Test')
-        end
-
-        it 'displays the post author' do
-            visit post_path(@post1)
-            expect(page).to have_content('Abdul')
-        end
-
-        it 'displays number of comments' do
-            visit post_path(@post1)
-            expect(page).to have_content('1')
-        end
-
-        it 'displays number of likes' do
-            visit post_path(@post1)
-            expect(page).to have_content('1')
-        end
-
-        it 'displays the post text' do
-            visit post_path(@post1)
-            expect(page).to have_content('First Post')
-        end
-
-        it 'displays the commentor' do
-            visit post_path(@post1)
-            expect(page).to have_content('Jonathan')
-        end
-
-        it 'displays the comment text' do
-            visit post_path(@post1)
-            expect(page).to have_content('First Comment')
-        end
+    it 'displays the post author' do
+      visit user_post_path(@user, @post1)
+      expect(page).to have_content('Abdul')
     end
+
+    it 'displays number of comments' do
+      visit user_post_path(@user, @post1)
+      expect(page).to have_content('1')
+    end
+
+    it 'displays number of likes' do
+      visit user_post_path(@user, @post1)
+      expect(page).to have_content('1')
+    end
+
+    it 'displays the post text' do
+      visit user_post_path(@user, @post1)
+      expect(page).to have_content('First Post')
+    end
+
+    it 'displays the commentor' do
+      visit user_post_path(@user, @post1)
+      expect(page).to have_content('Jonathan')
+    end
+
+    it 'displays the comment text' do
+      visit user_post_path(@user, @post1)
+      expect(page).to have_content('First Comment')
+    end
+  end
 end
-

--- a/spec/views/post_show_spec.rb
+++ b/spec/views/post_show_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe 'Post show page', type: :feature do
+    before(:each) do
+        @user = User.create(
+            name: 'Abdul',
+            bio: 'Aspiring FullStack Dev',
+            photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
+        )
+
+        @user2 = User.create(
+            name: 'Jonathan',
+            bio: 'FullStack Dev',
+            photo: 'https://unsplash.com/photos/hodKTZow_Kk',
+        )
+
+        @post1 = Post.create(
+            title: 'Test',
+            text: 'First Post',
+            author: @user
+        )
+
+        @comment1 = Comment.create(
+            text: 'First Comment',
+            post: @post1,
+            author: @user2
+        )
+
+        @like1 = Like.create(
+            post: @post1,
+            author: @user2
+        )
+
+    end
+
+    describe 'the post show page' do
+        it 'displays the post title' do
+            visit post_path(@post1)
+            expect(page).to have_content('Test')
+        end
+
+        it 'displays the post author' do
+            visit post_path(@post1)
+            expect(page).to have_content('Abdul')
+        end
+
+        it 'displays number of comments' do
+            visit post_path(@post1)
+            expect(page).to have_content('1')
+        end
+
+        it 'displays number of likes' do
+            visit post_path(@post1)
+            expect(page).to have_content('1')
+        end
+
+        it 'displays the post text' do
+            visit post_path(@post1)
+            expect(page).to have_content('First Post')
+        end
+
+        it 'displays the commentor' do
+            visit post_path(@post1)
+            expect(page).to have_content('Jonathan')
+        end
+
+        it 'displays the comment text' do
+            visit post_path(@post1)
+            expect(page).to have_content('First Comment')
+        end
+    end
+end
+

--- a/spec/views/user_index_spec.rb
+++ b/spec/views/user_index_spec.rb
@@ -1,53 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe 'User index', type: :feature do
-    before(:each) do
-        @user1 = User.create(
-            name: 'Abdul',
-            bio: 'Aspiring FullStack Dev',
-            photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
-            posts_counter: 2
-        )
+  before(:each) do
+    @user1 = User.create(
+      name: 'Abdul',
+      bio: 'Aspiring FullStack Dev',
+      photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
+      posts_counter: 2
+    )
 
-        @user2 = User.create(
-            name: 'Jonathan',
-            bio: 'FullStack Dev',
-            photo: 'https://unsplash.com/photos/hodKTZow_Kk',
-            posts_counter: 3
-        )
-end
+    @user2 = User.create(
+      name: 'Jonathan',
+      bio: 'FullStack Dev',
+      photo: 'https://unsplash.com/photos/hodKTZow_Kk',
+      posts_counter: 3
+    )
+  end
 
-describe 'user index paged' do 
-        it 'displays correct username' do
-            visit users_path
-            expect(page).to have_content('Abdul')
-            expect(page).to have_content('Jonathan')
-            expect(page).to_not have_content('Caicedo') 
-        end
-
-        it 'shows user profile photo' do
-            visit users_path
-            expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
-            expect(page).to have_css("img[src*='https://unsplash.com/photos/hodKTZow_Kk']")
-        end
-
-        it 'shows the correct number of posts' do
-            visit users_path
-
-            expect(page).to have_content('Number of posts: 2')
-            expect(page).to have_content('Number of posts: 3')
-        end
-
-        it 'shows the user_path when clicked' do
-            visit users_path
-            click_link 'Abdul'
-            expect(page).to have_current_path(user_path(@user1))
-        end
-
-        it 'it shows the bio in show path' do
-            visit users_path
-            click_link 'Jonathan'
-            expect(page).to have_content('FullStack Dev')
-        end
+  describe 'user index paged' do
+    it 'displays correct username' do
+      visit users_path
+      expect(page).to have_content('Abdul')
+      expect(page).to have_content('Jonathan')
+      expect(page).to_not have_content('Caicedo')
     end
+
+    it 'shows user profile photo' do
+      visit users_path
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/hodKTZow_Kk']")
+    end
+
+    it 'shows the correct number of posts' do
+      visit users_path
+
+      expect(page).to have_content('Number of posts: 2')
+      expect(page).to have_content('Number of posts: 3')
+    end
+
+    it 'shows the user_path when clicked' do
+      visit users_path
+      click_link 'Abdul'
+      expect(page).to have_current_path(user_path(@user1))
+    end
+
+    it 'it shows the bio in show path' do
+      visit users_path
+      click_link 'Jonathan'
+      expect(page).to have_content('FullStack Dev')
+    end
+  end
 end

--- a/spec/views/user_index_spec.rb
+++ b/spec/views/user_index_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+Rspec.describe 'User index' type: :feature do
+    before(:each) do
+        @user1 = User.create(
+            name: 'Abdul',
+            bio: 'Aspiring FullStack Dev',
+            photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
+            posts_counter: 2
+        )
+
+        @user2 = User.create(
+            name: 'Jonathan',
+            bio: 'FullStack Dev',
+            photo: 'https://unsplash.com/photos/hodKTZow_Kk',
+            posts_counter: 3
+        )
+end
+
+describe 'user index paged' do 
+        it 'displays correct username' do
+            visit users_path
+            expect(page).to_have_content('Abdul')
+            expect(page).to_have_content('Jonathan')
+            expect(page).to_not have_content('Caicedo') 
+        end
+
+        it 'shows user profile photo' do
+            visit users_path
+            expect(page).to_have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
+            expect(page).to_have_css("img[src*='https://unsplash.com/photos/hodKTZow_Kk']")
+        end
+
+        it 'shows the correct number of posts' do
+            visit users_path
+
+            expect(page).to_have_content('Number of posts: 2')
+            expect(page).to_have_content('Number of posts: 3')
+        end
+
+        it 'shows the user_path when clicked' do
+            visit users_path
+            click_link 'Abdul'
+            expect(page).to_have_current_path(user_path(@user1))
+        end
+
+        it 'it shows the bio in show path' do
+            visit users_path
+            click_link 'Jonathan'
+            expect(page).to_have_content('Fullstack Developer')
+        end
+    end
+end

--- a/spec/views/user_index_spec.rb
+++ b/spec/views/user_index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-Rspec.describe 'User index' type: :feature do
+RSpec.describe 'User index', type: :feature do
     before(:each) do
         @user1 = User.create(
             name: 'Abdul',
@@ -20,34 +20,34 @@ end
 describe 'user index paged' do 
         it 'displays correct username' do
             visit users_path
-            expect(page).to_have_content('Abdul')
-            expect(page).to_have_content('Jonathan')
+            expect(page).to have_content('Abdul')
+            expect(page).to have_content('Jonathan')
             expect(page).to_not have_content('Caicedo') 
         end
 
         it 'shows user profile photo' do
             visit users_path
-            expect(page).to_have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
-            expect(page).to_have_css("img[src*='https://unsplash.com/photos/hodKTZow_Kk']")
+            expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
+            expect(page).to have_css("img[src*='https://unsplash.com/photos/hodKTZow_Kk']")
         end
 
         it 'shows the correct number of posts' do
             visit users_path
 
-            expect(page).to_have_content('Number of posts: 2')
-            expect(page).to_have_content('Number of posts: 3')
+            expect(page).to have_content('Number of posts: 2')
+            expect(page).to have_content('Number of posts: 3')
         end
 
         it 'shows the user_path when clicked' do
             visit users_path
             click_link 'Abdul'
-            expect(page).to_have_current_path(user_path(@user1))
+            expect(page).to have_current_path(user_path(@user1))
         end
 
         it 'it shows the bio in show path' do
             visit users_path
             click_link 'Jonathan'
-            expect(page).to_have_content('Fullstack Dev')
+            expect(page).to have_content('FullStack Dev')
         end
     end
 end

--- a/spec/views/user_index_spec.rb
+++ b/spec/views/user_index_spec.rb
@@ -47,7 +47,7 @@ describe 'user index paged' do
         it 'it shows the bio in show path' do
             visit users_path
             click_link 'Jonathan'
-            expect(page).to_have_content('Fullstack Developer')
+            expect(page).to_have_content('Fullstack Dev')
         end
     end
 end

--- a/spec/views/user_show_spec.rb
+++ b/spec/views/user_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-Rspec.describe 'User show page' type: :feature do
+RSpec.describe 'User show page', type: :feature do
     before(:each) do
         @user = User.create(
             name: 'Abdul',
@@ -30,45 +30,45 @@ end
     describe 'the user show page' do 
         it 'displays the user profile picture' do
             visit user_path(@user)
-            expect(page).to_have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
+            expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
         end
 
         it ' displays user username' do
             visit user_path(@user)
-            expect(page).to_have_content('Abdul')
+            expect(page).to have_content('Abdul')
         end
 
         it 'shows the number of posts the user has written' do
             visit user_path(@user)
-            expect(page).to_have_content('2')
+            expect(page).to have_content('2')
         end
 
         it 'displays the user bio' do
             visit user_path(@user)
-            expect(page).to_have_content('Aspiring FullStack Dev')
+            expect(page).to have_content('Aspiring FullStack Dev')
         end
 
         it 'display the first three posts by the user' do
             visit user_path(@user)
-            expect(page).to_have_content('First Post')
-            expect(page).to_have_content('Second Post')
+            expect(page).to have_content('First Post')
+            expect(page).to have_content('Second Post')
         end
 
         it 'displays a button for all user posts' do
             visit user_path(@user)
-            expect(page).to_have_content('see all posts')
+            expect(page).to have_content('See all posts')
         end
 
         it 'click a user post, it redirects to that specific post show page' do
-            visit user_path
+            visit user_path(@user)
             click_link 'Test'
-            expect(page).to_have_current_path(user_post_path(@user, @post1))
+            expect(page).to have_current_path(user_post_path(@user, @post1))
         end
 
         it 'click to see all posts, it redirects to the user post index page' do
-            visit user_path
-            click_link 'see all posts'
-            expect(page).to_have_current_path(user_posts_path(@user))
+            visit user_path(@user)
+            click_link 'See all posts'
+            expect(page).to have_current_path(user_posts_path(@user))
         end
     end
 end

--- a/spec/views/user_show_spec.rb
+++ b/spec/views/user_show_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+Rspec.describe 'User show page' type: :feature do
+    before(:each) do
+        @user = User.create(
+            name: 'Abdul',
+            bio: 'Aspiring FullStack Dev',
+            photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
+            posts_counter: 2
+        )
+
+        @post1 = Post.create(
+            author: @user,
+            title: 'Test',
+            text: 'First Post',
+            comments_counter: 1,
+            likes_counter: 1
+        )
+
+        @post2 = Post.create(
+            author: @user,
+            title: 'Working?',
+            text: 'Second Post',
+            comments_counter: 1,
+            likes_counter: 2
+        )
+
+end
+
+    describe 'the user show page' do 
+        it 'displays the user profile picture' do
+            visit user_path(@user)
+            expect(page).to_have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
+        end
+
+        it ' displays user username' do
+            visit user_path(@user)
+            expect(page).to_have_content('Abdul')
+        end
+
+        it 'shows the number of posts the user has written' do
+            visit user_path(@user)
+            expect(page).to_have_content('2')
+        end
+
+        it 'displays the user bio' do
+            visit user_path(@user)
+            expect(page).to_have_content('Aspiring FullStack Dev')
+        end
+
+        it 'display the first three posts by the user' do
+            visit user_path(@user)
+            expect(page).to_have_content('First Post')
+            expect(page).to_have_content('Second Post')
+        end
+
+        it 'displays a button for all user posts' do
+            visit user_path(@user)
+            expect(page).to_have_content('see all posts')
+        end
+
+        it 'click a user post, it redirects to that specific post show page' do
+            visit user_path
+            click_link 'Test'
+            expect(page).to_have_current_path(user_post_path(@user, @post1))
+        end
+
+        it 'click to see all posts, it redirects to the user post index page' do
+            visit user_path
+            click_link 'see all posts'
+            expect(page).to_have_current_path(user_posts_path(@user))
+        end
+    end
+end
+

--- a/spec/views/user_show_spec.rb
+++ b/spec/views/user_show_spec.rb
@@ -1,75 +1,73 @@
 require 'rails_helper'
 
 RSpec.describe 'User show page', type: :feature do
-    before(:each) do
-        @user = User.create(
-            name: 'Abdul',
-            bio: 'Aspiring FullStack Dev',
-            photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
-            posts_counter: 2
-        )
+  before(:each) do
+    @user = User.create(
+      name: 'Abdul',
+      bio: 'Aspiring FullStack Dev',
+      photo: 'https://unsplash.com/photos/NDCy2-9JhUs',
+      posts_counter: 2
+    )
 
-        @post1 = Post.create(
-            author: @user,
-            title: 'Test',
-            text: 'First Post',
-            comments_counter: 1,
-            likes_counter: 1
-        )
+    @post1 = Post.create(
+      author: @user,
+      title: 'Test',
+      text: 'First Post',
+      comments_counter: 1,
+      likes_counter: 1
+    )
 
-        @post2 = Post.create(
-            author: @user,
-            title: 'Working?',
-            text: 'Second Post',
-            comments_counter: 1,
-            likes_counter: 2
-        )
+    @post2 = Post.create(
+      author: @user,
+      title: 'Working?',
+      text: 'Second Post',
+      comments_counter: 1,
+      likes_counter: 2
+    )
+  end
 
-end
-
-    describe 'the user show page' do 
-        it 'displays the user profile picture' do
-            visit user_path(@user)
-            expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
-        end
-
-        it ' displays user username' do
-            visit user_path(@user)
-            expect(page).to have_content('Abdul')
-        end
-
-        it 'shows the number of posts the user has written' do
-            visit user_path(@user)
-            expect(page).to have_content('2')
-        end
-
-        it 'displays the user bio' do
-            visit user_path(@user)
-            expect(page).to have_content('Aspiring FullStack Dev')
-        end
-
-        it 'display the first three posts by the user' do
-            visit user_path(@user)
-            expect(page).to have_content('First Post')
-            expect(page).to have_content('Second Post')
-        end
-
-        it 'displays a button for all user posts' do
-            visit user_path(@user)
-            expect(page).to have_content('See all posts')
-        end
-
-        it 'click a user post, it redirects to that specific post show page' do
-            visit user_path(@user)
-            click_link 'Test'
-            expect(page).to have_current_path(user_post_path(@user, @post1))
-        end
-
-        it 'click to see all posts, it redirects to the user post index page' do
-            visit user_path(@user)
-            click_link 'See all posts'
-            expect(page).to have_current_path(user_posts_path(@user))
-        end
+  describe 'the user show page' do
+    it 'displays the user profile picture' do
+      visit user_path(@user)
+      expect(page).to have_css("img[src*='https://unsplash.com/photos/NDCy2-9JhUs']")
     end
-end
 
+    it ' displays user username' do
+      visit user_path(@user)
+      expect(page).to have_content('Abdul')
+    end
+
+    it 'shows the number of posts the user has written' do
+      visit user_path(@user)
+      expect(page).to have_content('2')
+    end
+
+    it 'displays the user bio' do
+      visit user_path(@user)
+      expect(page).to have_content('Aspiring FullStack Dev')
+    end
+
+    it 'display the first three posts by the user' do
+      visit user_path(@user)
+      expect(page).to have_content('First Post')
+      expect(page).to have_content('Second Post')
+    end
+
+    it 'displays a button for all user posts' do
+      visit user_path(@user)
+      expect(page).to have_content('See all posts')
+    end
+
+    it 'click a user post, it redirects to that specific post show page' do
+      visit user_path(@user)
+      click_link 'Test'
+      expect(page).to have_current_path(user_post_path(@user, @post1))
+    end
+
+    it 'click to see all posts, it redirects to the user post index page' do
+      visit user_path(@user)
+      click_link 'See all posts'
+      expect(page).to have_current_path(user_posts_path(@user))
+    end
+  end
+end


### PR DESCRIPTION
This pull request consists of the following changes.

- Solved N + 1 problem when fetching all posts and their comments for a user.
Log for User Post index page before adding eager loading 
<img width="765" alt="posts index before" src="https://user-images.githubusercontent.com/11190489/216073300-6bc95fc9-a5d7-48d3-9a61-4d693e93a924.PNG">

Log for User Post index page after adding eager loading 
<img width="733" alt="posts index after" src="https://user-images.githubusercontent.com/11190489/216073358-a8e20a4c-54e6-4e11-80ce-8c51368b0686.PNG">

Log for Post show page before adding eager loading 
<img width="747" alt="post and comments before" src="https://user-images.githubusercontent.com/11190489/216073405-f1f5b28d-4b66-4653-a166-9a4630806c3a.PNG">

Log for Post show page after adding eager loading 
<img width="715" alt="posts show after" src="https://user-images.githubusercontent.com/11190489/216073443-e116d948-cd23-43c7-8edb-4bbda005b494.PNG">

- Used Capybara to write integration tests for each view. 
`User index page`
`user show page`
`User post index page`
`Post show page`